### PR TITLE
Adjustments for pyright/pylance + modernising to use ruff

### DIFF
--- a/.github/dependabot.yml
+++ b/.github/dependabot.yml
@@ -1,0 +1,8 @@
+version: 2
+updates:
+
+  - package-ecosystem: "github-actions"
+    directory: "/"
+    schedule:
+      # Check for updates to GitHub Actions every week
+      interval: "weekly"

--- a/.pre-commit-config.yaml
+++ b/.pre-commit-config.yaml
@@ -3,7 +3,7 @@ default_language_version:
 
 repos:
   - repo: https://github.com/pre-commit/pre-commit-hooks
-    rev: v4.4.0
+    rev: v4.5.0
     hooks:
       - id: trailing-whitespace
       - id: end-of-file-fixer
@@ -11,17 +11,17 @@ repos:
         pass_filenames: false
       - id: check-added-large-files
   - repo: https://github.com/pycqa/isort
-    rev: '5.12.0'
+    rev: '5.13.2'
     hooks:
       - id: isort
         exclude: '{{ cookiecutter.project_name }}'
   - repo: https://github.com/psf/black
-    rev: '23.1.0'
+    rev: '23.12.1'
     hooks:
       - id: black
         exclude: '{{ cookiecutter.project_name }}'
   - repo: https://github.com/pycqa/flake8
-    rev: '6.0.0'
+    rev: '7.0.0'
     hooks:
       - id: flake8
         exclude: '{{ cookiecutter.project_name }}'

--- a/.pre-commit-config.yaml
+++ b/.pre-commit-config.yaml
@@ -10,18 +10,19 @@ repos:
       - id: check-toml
         pass_filenames: false
       - id: check-added-large-files
-  - repo: https://github.com/pycqa/isort
-    rev: '5.13.2'
+  - repo: https://github.com/astral-sh/ruff-pre-commit
+    # Ruff version.
+    rev: v0.1.13
     hooks:
-      - id: isort
-        exclude: '{{ cookiecutter.project_name }}'
-  - repo: https://github.com/psf/black
-    rev: '23.12.1'
-    hooks:
-      - id: black
-        exclude: '{{ cookiecutter.project_name }}'
-  - repo: https://github.com/pycqa/flake8
-    rev: '7.0.0'
-    hooks:
-      - id: flake8
-        exclude: '{{ cookiecutter.project_name }}'
+      # Run the linter.
+      - id: ruff
+        args: ["--fix", "--config", "pyproject.toml"]
+      # Run the formatter.
+      - id: ruff-format
+        # The "--config pyproject.toml" here and above prevent ruff
+        # from looking at the pyproject.toml in the {{ .... }} dir as
+        # a possible config file. Ruff on the commandline ignores it
+        # just fine, but when passed explicitly as filename by git it
+        # still gets read.
+        # See https://github.com/astral-sh/ruff/issues/9585
+        args: ["--config", "pyproject.toml"]

--- a/CHANGES.md
+++ b/CHANGES.md
@@ -4,7 +4,22 @@
 ## 0.6 (unreleased)
 
 
-- Nothing changed yet.
+- Requiring python 3.10 in the generated project.
+
+- Moved to ruff: this includes black, isort, pyflakes and
+  pyupgrade. Including configuration that enables it.
+
+- Setup.cfg is gone now, everything is in pyproject.toml.
+
+- Documenting that you should generate the virtualenv in the `./venv`
+  dir instead of directly in `.`, this matches the python.org docs.
+
+- Added initial configuration for pyright/pylance, this helps vscode
+  and other LSP-using editors. (partially helped by the abovementioned
+  `./venv` change).
+
+- Updated github actions and added the dependabot "github action
+  autoupdater".
 
 
 ## 0.5 (2023-03-29)

--- a/README.md
+++ b/README.md
@@ -19,7 +19,7 @@ Run the following command and answer the questions:
 
 Just do the regular:
 
-    $ python3 -m venv .
-    $ bin/pip install -e .[test]
+    $ python3 -m venv venv
+    $ venv/bin/pip install -e .[test]
     $ pre-commit install
-    $ bin/pytest
+    $ venv/bin/pytest

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -44,3 +44,8 @@ addopts = "tests/"
 [tool.zest-releaser]
 # We don't need releasing as a package.
 release = false
+
+[tool.pyright]
+include = "test"
+venvPath = "."
+venv = "venv"

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -48,6 +48,10 @@ release = false
 [tool.ruff]
 exclude = ["*cookiecutter.project_name*"]
 
+[tool.ruff.lint]
+# Default select: ["E4", "E7", "E9", "F"]
+select = ["E4", "E7", "E9", "F", "I", "UP"]
+
 [tool.pyright]
 include = "test"
 venvPath = "."

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -45,6 +45,9 @@ addopts = "tests/"
 # We don't need releasing as a package.
 release = false
 
+[tool.ruff]
+exclude = ["*cookiecutter.project_name*"]
+
 [tool.pyright]
 include = "test"
 venvPath = "."

--- a/{{ cookiecutter.project_name }}/.github/dependabot.yml
+++ b/{{ cookiecutter.project_name }}/.github/dependabot.yml
@@ -1,0 +1,8 @@
+version: 2
+updates:
+
+  - package-ecosystem: "github-actions"
+    directory: "/"
+    schedule:
+      # Check for updates to GitHub Actions every week
+      interval: "weekly"

--- a/{{ cookiecutter.project_name }}/.github/workflows/lint.yml
+++ b/{{ cookiecutter.project_name }}/.github/workflows/lint.yml
@@ -12,10 +12,10 @@ jobs:
   lint:
     runs-on: ubuntu-latest
     steps:
-      - uses: actions/checkout@v3
+      - uses: actions/checkout@v4
 
       - name: Set up Python
-        uses: actions/setup-python@v4
+        uses: actions/setup-python@v5
         with:
           python-version: "3.10"
 

--- a/{{ cookiecutter.project_name }}/.github/workflows/test.yml
+++ b/{{ cookiecutter.project_name }}/.github/workflows/test.yml
@@ -15,17 +15,14 @@ jobs:
       fail-fast: false
       matrix:
         include:
-          # 2019
-          - python: 3.8
-            pins: ""
-          # 2021
-          - python: 3.9
-            pins: ""
           # 2022
           - python: "3.10"
             pins: ""
-          # current
+          # 2023
           - python: "3.11"
+            pins: ""
+          # 2023
+          - python: "3.12"
             pins: ""
 
     steps:

--- a/{{ cookiecutter.project_name }}/.github/workflows/test.yml
+++ b/{{ cookiecutter.project_name }}/.github/workflows/test.yml
@@ -26,10 +26,10 @@ jobs:
             pins: ""
 
     steps:
-      - uses: actions/checkout@v3
+      - uses: actions/checkout@v4
 
       - name: Set up Python ${{ matrix.python }}
-        uses: actions/setup-python@v4
+        uses: actions/setup-python@v5
         with:
           python-version: ${{ matrix.python }}
 

--- a/{{ cookiecutter.project_name }}/.pre-commit-config.yaml
+++ b/{{ cookiecutter.project_name }}/.pre-commit-config.yaml
@@ -10,19 +10,12 @@ repos:
       - id: check-yaml
       - id: check-toml
       - id: check-added-large-files
-  - repo: https://github.com/pycqa/isort
-    rev: '5.12.0'
+  - repo: https://github.com/astral-sh/ruff-pre-commit
+    # Ruff version.
+    rev: v0.1.13
     hooks:
-      - id: isort
-        exclude: 'settings'
-  - repo: https://github.com/psf/black
-    rev: '23.1.0'
-    hooks:
-      - id: black
-        exclude: 'migrations*|urls*|settings*'
-  - repo: https://github.com/pycqa/flake8
-    rev: '6.0.0'
-    hooks:
-      - id: flake8
-        # NB The "exclude" setting in setup.cfg is ignored by pre-commit
-        exclude: 'migrations*|urls*|settings*'
+      # Run the linter.
+      - id: ruff
+        args: ["--fix"]
+      # Run the formatter.
+      - id: ruff-format

--- a/{{ cookiecutter.project_name }}/README.md
+++ b/{{ cookiecutter.project_name }}/README.md
@@ -18,16 +18,18 @@ We can be installed with:
 We use python's build-in "virtualenv" to get a nice isolated
 directory. You only need to run this once:
 
-    $ python3 -m venv .
+    $ python3 -m venv venv
 
-A virtualenv puts its commands in the `bin` directory. So `bin/pip`,
-`bin/pytest`, etc. Set up the dependencies like this:
+A virtualenv puts its commands in the `venv/bin` directory. So
+`venv/bin/pip`, `venv/bin/pytest`, etc. (You can also activate the
+virtualenv instead of explicitly passing `venv/bin/...`). Set up the
+dependencies like this:
 
-    $ bin/pip install -e .[test]
+    $ venv/bin/pip install -e .[test]
 
 There will be a script you can run like this:
 
-    $ bin/run-{{ cookiecutter.project_name }}
+    $ venv/bin/run-{{ cookiecutter.project_name }}
 
 It runs the `main()` function in `[{{ cookiecutter.project_name }}/scripts.py`,
 adjust that if necessary. The script is configured in
@@ -41,7 +43,7 @@ it on this project:
 
 Run the tests regularly with coverage:
 
-    $ bin/pytest --cov
+    $ venv/bin/pytest --cov
 
 The tests are also run automatically [on "github
 actions"](https://github.com/nens/{{ cookiecutter.project_name }}/actions) for
@@ -52,7 +54,7 @@ the feedback from the automated tests.
 If you need a new dependency (like `requests`), add it in
 `pyproject.toml` in `dependencies`. And update your local install with:
 
-    $ bin/pip install -e .[test]
+    $ venv/bin/pip install -e .[test]
 
 
 ## Steps to do after generating with cookiecutter

--- a/{{ cookiecutter.project_name }}/pyproject.toml
+++ b/{{ cookiecutter.project_name }}/pyproject.toml
@@ -35,12 +35,22 @@ include = ["{{ cookiecutter.package_name }}*"]
 [tool.setuptools.dynamic]
 version = {attr = "{{ cookiecutter.package_name }}.__version__"}
 
-[tool.isort]
-profile = "black"
-force_alphabetical_sort_within_sections = true
-force_single_line = true
-
 [tool.pytest.ini_options]
-norecursedirs=".venv data doc etc *.egg-info misc var build lib include"
+norecursedirs="venv .venv data doc etc *.egg-info misc var build lib include"
 python_files = "test_*.py"
 testpaths = "{{ cookiecutter.package_name }}"
+
+[tool.zestreleaser]
+release = false
+python-file-with-version = "{{ cookiecutter.package_name }}/__init__.py"
+
+[tool.ruff]
+# See https://docs.astral.sh/ruff/configuration/ for defaults.
+target-version = "py310"
+
+[tool.ruff.lint]
+# Default select: ["E4", "E7", "E9", "F"]
+select = ["E4", "E7", "E9", "F", "I", "UP"]
+
+[tool.ruff.lint.isort]
+known-first-party = ["{{ cookiecutter.package_name }}"]

--- a/{{ cookiecutter.project_name }}/pyproject.toml
+++ b/{{ cookiecutter.project_name }}/pyproject.toml
@@ -9,7 +9,7 @@ license = {text = "MIT"}
 # Get classifier strings from http://www.python.org/pypi?%3Aaction=list_classifiers
 classifiers = ["Programming Language :: Python"]
 keywords = []
-requires-python = ">=3.7"
+requires-python = ">=3.10"
 dependencies = []
 dynamic = ["version"]
 

--- a/{{ cookiecutter.project_name }}/pyproject.toml
+++ b/{{ cookiecutter.project_name }}/pyproject.toml
@@ -40,7 +40,7 @@ norecursedirs="venv .venv data doc etc *.egg-info misc var build lib include"
 python_files = "test_*.py"
 testpaths = "{{ cookiecutter.package_name }}"
 
-[tool.zestreleaser]
+[tool.zest-releaser]
 release = false
 python-file-with-version = "{{ cookiecutter.package_name }}/__init__.py"
 

--- a/{{ cookiecutter.project_name }}/pyproject.toml
+++ b/{{ cookiecutter.project_name }}/pyproject.toml
@@ -50,7 +50,7 @@ target-version = "py310"
 
 [tool.ruff.lint]
 # Default select: ["E4", "E7", "E9", "F"]
-select = ["E4", "E7", "E9", "F", "I", "UP"]
+select = ["E4", "E7", "E9", "F", "I", "UP", "C901"]
 
 [tool.ruff.lint.isort]
 known-first-party = ["{{ cookiecutter.package_name }}"]

--- a/{{ cookiecutter.project_name }}/pyproject.toml
+++ b/{{ cookiecutter.project_name }}/pyproject.toml
@@ -54,3 +54,11 @@ select = ["E4", "E7", "E9", "F", "I", "UP"]
 
 [tool.ruff.lint.isort]
 known-first-party = ["{{ cookiecutter.package_name }}"]
+
+[tool.pyright]
+# Pyright/pylance/vscode configuration.
+# Note: if you want a different setup, you can overwrite this with a
+# "pyrightconfig.json", which takes precedence.
+include = "{{ cookiecutter.package_name }}"
+venvPath = "."
+venv = "venv"

--- a/{{ cookiecutter.project_name }}/setup.cfg
+++ b/{{ cookiecutter.project_name }}/setup.cfg
@@ -1,7 +1,0 @@
-[zest.releaser]
-release = no
-python-file-with-version = {{ cookiecutter.package_name }}/__init__.py
-
-[flake8]
-max-line-length = 88
-ignore = E203, E266, E501, W503

--- a/{{ cookiecutter.project_name }}/{{cookiecutter.package_name}}/tests/test_scripts.py
+++ b/{{ cookiecutter.project_name }}/{{cookiecutter.package_name}}/tests/test_scripts.py
@@ -1,4 +1,3 @@
-# -*- coding: utf-8 -*-
 """Tests for script.py"""
 from {{ cookiecutter.package_name }} import scripts
 


### PR DESCRIPTION
Virtualenv in `venv` instead of in `.`, this works better with pyright/pylance/vscode. And it is suggested in the python documentation (together with `.venv`, but the dotless version is used everywhere in the docs).

I've modernised everything to use `ruff`: this way we don't have black/flake8/isort anymore. This also got rid of the last stuff in `setup.cfg` :-)

Here's what I put in the changelog, for completeness:

- Requiring python 3.10 in the generated project.
- Moved to ruff: this includes black, isort, pyflakes and
  pyupgrade. Including configuration that enables it.
- Setup.cfg is gone now, everything is in pyproject.toml.
- Documenting that you should generate the virtualenv in the `./venv`
  dir instead of directly in `.`, this matches the python.org docs.
- Added initial configuration for pyright/pylance, this helps vscode
  and other LSP-using editors. (partially helped by the abovementioned
  `./venv` change).
- Updated github actions and added the dependabot "github action
  autoupdater".
