### PR TITLE
Various improvements to pyproject toml

### DIFF
--- a/pyproject.toml
+++ b/pyproject.toml
@@ -24,6 +24,7 @@ dependencies = [
     "cookiecutter"
 ]
 
+
 [project.urls]
 homepage = "https://github.com/nens/cookiecutter-python-template"
 
@@ -42,9 +43,3 @@ target-version = "py312"
 [tool.ruff.lint]
 select = ["E4", "E7", "E9", "F", "I", "UP", "C901"]
 
-[dependency-groups]
-dev = [
-    "pre-commit>=4.3.0",
-    "pytest>=8.4.2",
-    "pytest-sugar>=1.1.1",
-]

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -24,7 +24,6 @@ dependencies = [
     "cookiecutter"
 ]
 
-
 [project.urls]
 homepage = "https://github.com/nens/cookiecutter-python-template"
 
@@ -43,3 +42,9 @@ target-version = "py312"
 [tool.ruff.lint]
 select = ["E4", "E7", "E9", "F", "I", "UP", "C901"]
 
+[dependency-groups]
+dev = [
+    "pre-commit>=4.3.0",
+    "pytest>=8.4.2",
+    "pytest-sugar>=1.1.1",
+]

--- a/{{ cookiecutter.project_name }}/.github/workflows/test.yml
+++ b/{{ cookiecutter.project_name }}/.github/workflows/test.yml
@@ -5,6 +5,7 @@ on:
   push:
     branches:
       - master
+      - main
   pull_request:
 
 jobs:

--- a/{{ cookiecutter.project_name }}/pyproject.toml
+++ b/{{ cookiecutter.project_name }}/pyproject.toml
@@ -18,11 +18,11 @@ keywords = []
 requires-python = ">=3.12"
 dependencies = []
 
+[project.optional-dependencies]
+test = ["pytest>=8.4.2", "pytest-cov>=6.3.0", "pytest-sugar>=1.1.1"]
+
 [project.urls]
 homepage = "https://github.com/nens/{{ cookiecutter.project_name }}"
-
-[tool.pytest.ini_options]
-addopts = "--cov --cov-fail-under=80"
 
 [tool.zest-releaser]
 release = false
@@ -38,6 +38,10 @@ select = ["E4", "E7", "E9", "F", "I", "UP", "C901"]
 [tool.ruff.lint.isort]
 known-first-party = ["{{ cookiecutter.package_name }}"]
 
+
+[tool.ruff.lint.per-file-ignores]
+"__init__.py" = ["F401", "F403"]
+
 [tool.pyright]
 # Pyright/pylance/vscode configuration.
 # Note: if you want a different setup, you can overwrite this with a
@@ -45,6 +49,3 @@ known-first-party = ["{{ cookiecutter.package_name }}"]
 include = "src"
 venvPath = "."
 venv = ".venv"
-
-[dependency-groups]
-dev = ["pytest>=8.4.2", "pytest-cov>=6.3.0", "pytest-sugar>=1.1.1"]


### PR DESCRIPTION
- Change dependency groups to optional dependencies so that you can install them using `install -e .[test]`
- Also changed the name of the dependency group from `dev` to `test` to match the GH action
- Removed the `--cov` pytest options because it breaks VS Code Python extension
- Allow the * and unused imports in `__init__` files (F401/F403), because that is the way we define public API's (combined with an `__all__` = [stuff you want to expose]` in the modules